### PR TITLE
task 1 - disable the button, change it to grey when no lat long

### DIFF
--- a/client/components/Button/Button.css
+++ b/client/components/Button/Button.css
@@ -13,4 +13,9 @@
     margin-left: calc($base-spacing * 2);
     box-shadow: $button-shadow;
   }
+
+  &[disabled] {
+    background-color: $starGrey;
+    cursor: not-allowed;
+  }
 }

--- a/client/components/Button/Button.js
+++ b/client/components/Button/Button.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import styles from './Button.css';
 
-const Button = ({ onClick, children, theme }) => {
+const Button = ({ onClick, children, theme, isDisabled }) => {
   return (
     <button
       className={classNames({
@@ -11,6 +11,7 @@ const Button = ({ onClick, children, theme }) => {
         [styles[theme]]: true,
       })}
       onClick={onClick}
+      disabled={isDisabled}
     >
       { children }
     </button>
@@ -23,6 +24,7 @@ Button.propTypes = {
   ]),
   onClick: PropTypes.func,
   theme: PropTypes.string,
+  isDisabled: PropTypes.bool,
 };
 
 export default Button;

--- a/client/containers/HomePage.js
+++ b/client/containers/HomePage.js
@@ -7,6 +7,7 @@ import placeActions from 'actions/placeActions';
 import conditionActions from 'actions/conditionActions';
 import Place from 'components/Place/Place';
 import Condition from 'components/Condition/Condition';
+import { hasLatLng } from 'lib/utils';
 
 class HomePage extends Component {
   handleOnClick = () => {
@@ -23,7 +24,7 @@ class HomePage extends Component {
         <Place place={place} />
         <div className="searchWrapper">
           <Condition condition={condition} action={this.handleOnConditionChange}/>
-          <Button onClick={this.handleOnClick} theme="homepageClick" />
+          <Button onClick={this.handleOnClick} theme="homepageClick" isDisabled={!hasLatLng(condition)} />
         </div>
       </div>
     );

--- a/client/lib/utils.js
+++ b/client/lib/utils.js
@@ -3,3 +3,8 @@ export function getRandom(list) {
   const rand = list[Math.floor(Math.random() * list.length)];
   return rand;
 }
+
+export function hasLatLng(obj) {
+  const { latitude, longitude } = obj;
+  return !isNaN(latitude) && !isNaN(longitude);
+}


### PR DESCRIPTION
Currently after you load the page then immediately click on the green button, server will throw out errors because it doesn't know your lat long yet.

We want to disable the green button and change it to grey before we finish fetching the user's lat long. Once lat long's values were set, we'll continue.